### PR TITLE
add audit logging to improve debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.0-beta2 (Dan Reynolds)
+
+- Bumps to latest Apollo version (3.1)
+- Adds audit logging for better entity debugging through the type map and invalidation policy manager
+
 1.0.0-beta1 (Dan Reynolds)
 
 - Initial beta release 🚀

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta1",
+  "version": "1.0.0-beta2",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "test": "jest",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",

--- a/src/audit/AuditLog.ts
+++ b/src/audit/AuditLog.ts
@@ -1,0 +1,41 @@
+import _ from "lodash";
+
+interface AuditLogEntry {
+  time: number;
+  type: string;
+  event: string;
+  meta?: Record<string, any>;
+  group?: string;
+}
+
+export default class AuditLog {
+  private _log: AuditLogEntry[] = [];
+
+  log(event: string, type: string, group?: string, meta?: Record<string, any>) {
+    const auditLogEntry = {
+      time: Date.now(),
+      type,
+      event,
+      meta,
+      group,
+    };
+    this._log.push(auditLogEntry);
+  }
+
+  getLog(filter: AuditLogEntry) {
+    return _.filter(this._log, filter);
+  }
+
+  printLog(filter: AuditLogEntry) {
+    this.getLog(filter).forEach(this.printLogEntry);
+  }
+
+  printLogEntry(entry: AuditLogEntry) {
+    console.log(`%c event: ${entry.event}`, "color: green");
+    console.group();
+    console.log(`type: ${entry.type}`);
+    console.log(`time: ${entry.time}`);
+    console.log(`meta: ${JSON.stringify(entry.meta ?? {})}`);
+    console.groupEnd();
+  }
+}

--- a/src/audit/EntityTypeMapAuditor.ts
+++ b/src/audit/EntityTypeMapAuditor.ts
@@ -1,0 +1,53 @@
+import EntityTypeMap from "../entity-store/EntityTypeMap";
+import AuditLog from "./AuditLog";
+
+interface EntityTypeMapAudtiorConfig {
+  auditLog: AuditLog;
+}
+
+enum EntityTypeMapAuditorEvent {
+  Write = "Write",
+  Evict = "Evict",
+}
+
+export default class EntityTypeMapAudtior extends EntityTypeMap {
+  private auditLog: AuditLog;
+
+  constructor(config: EntityTypeMapAudtiorConfig) {
+    super();
+    this.auditLog = config.auditLog;
+  }
+
+  write(
+    typename: string,
+    dataId: string,
+    storeFieldName?: string | null,
+    variables?: Record<string, any>
+  ) {
+    this.auditLog.log(
+      "Writing to type map",
+      EntityTypeMapAuditorEvent.Write,
+      "EntityTypeMap",
+      {
+        typename,
+        dataId,
+        storeFieldName,
+        variables,
+      }
+    );
+    return super.write(typename, dataId, storeFieldName, variables);
+  }
+
+  evict(dataId: string, storeFieldName?: string): void {
+    this.auditLog.log(
+      "Evicting from type map",
+      EntityTypeMapAuditorEvent.Evict,
+      "EntityTypeMap",
+      {
+        dataId,
+        storeFieldName,
+      }
+    );
+    return super.evict(dataId, storeFieldName);
+  }
+}

--- a/src/audit/InvalidationPolicyCacheAuditor.ts
+++ b/src/audit/InvalidationPolicyCacheAuditor.ts
@@ -1,0 +1,38 @@
+import InvalidationPolicyCache from "../cache/InvalidationPolicyCache";
+import { CacheResultProcessor } from "../cache/CacheResultProcessor";
+import InvalidationPolicyManagerAuditor from "./InvalidationPolicyManagerAuditor";
+import EntityTypeMapAuditor from "./EntityTypeMapAuditor";
+import { InvalidationPolicyCacheConfig } from "../cache/types";
+import AuditLog from "./AuditLog";
+import { EntityStoreWatcher } from "../entity-store";
+
+export default class InvalidationPolicyCacheAuditor extends InvalidationPolicyCache {
+  auditLog = new AuditLog();
+
+  constructor(config: InvalidationPolicyCacheConfig) {
+    super(config);
+    const { invalidationPolicies = {} } = config;
+
+    this.entityTypeMap = new EntityTypeMapAuditor({ auditLog: this.auditLog });
+    new EntityStoreWatcher({
+      entityStore: this.entityStoreRoot,
+      entityTypeMap: this.entityTypeMap,
+      policies: this.policies,
+    });
+    this.invalidationPolicyManager = new InvalidationPolicyManagerAuditor({
+      auditLog: this.auditLog,
+      policies: invalidationPolicies,
+      entityTypeMap: this.entityTypeMap,
+      cacheOperations: {
+        evict: this.evict.bind(this),
+        modify: this.modify.bind(this),
+        readField: this.readField.bind(this),
+      },
+    });
+    this.cacheResultProcessor = new CacheResultProcessor({
+      invalidationPolicyManager: this.invalidationPolicyManager,
+      entityTypeMap: this.entityTypeMap,
+      cache: this,
+    });
+  }
+}

--- a/src/audit/InvalidationPolicyManagerAuditor.ts
+++ b/src/audit/InvalidationPolicyManagerAuditor.ts
@@ -1,0 +1,75 @@
+import InvalidationPolicyManager from "../policies/InvalidationPolicyManager";
+import AuditLog from "./AuditLog";
+import {
+  PolicyActionMeta,
+  InvalidationPolicyManagerConfig,
+} from "../policies/types";
+
+export enum AuditType {
+  Read = "Read",
+  Write = "Write",
+  Evict = "Evict",
+}
+
+interface InvalidationPolicyManagerAuditorConfig
+  extends InvalidationPolicyManagerConfig {
+  auditLog: AuditLog;
+}
+
+export default class InvalidationPolicyManagerAuditor extends InvalidationPolicyManager {
+  private auditLog: AuditLog;
+
+  constructor(config: InvalidationPolicyManagerAuditorConfig) {
+    super(config);
+    this.auditLog = config.auditLog;
+  }
+
+  runReadPolicy(
+    typename: string,
+    dataId: string,
+    fieldName?: string,
+    storeFieldName?: string
+  ) {
+    this.auditLog.log(
+      "Running read policy",
+      AuditType.Read,
+      "InvalidationPolicyManager",
+      {
+        storeFieldName,
+        typename,
+        dataId,
+        fieldName,
+      }
+    );
+
+    return super.runReadPolicy(typename, dataId, fieldName, storeFieldName);
+  }
+
+  runWritePolicy(typeName: string, policyMeta: PolicyActionMeta) {
+    this.auditLog.log(
+      "Running write policy",
+      AuditType.Write,
+      "InvalidationPolicyManager",
+      {
+        typeName,
+        ...policyMeta,
+      }
+    );
+
+    return super.runWritePolicy(typeName, policyMeta);
+  }
+
+  runEvictPolicy(typeName: string, policyMeta: PolicyActionMeta) {
+    this.auditLog.log(
+      "Running evict policy",
+      AuditType.Write,
+      "InvalidationPolicyManager",
+      {
+        typeName,
+        ...policyMeta,
+      }
+    );
+
+    return super.runEvictPolicy(typeName, policyMeta);
+  }
+}

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -1,0 +1,1 @@
+export { default as InvalidationPolicyCacheAuditor } from "./InvalidationPolicyCacheAuditor";

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -21,11 +21,11 @@ import { InvalidationPolicyEvent } from "../policies/types";
  * Extension of Apollo in-memory cache which adds support for invalidation policies.
  */
 export default class InvalidationPolicyCache extends InMemoryCache {
-  private entityTypeMap: EntityTypeMap;
-  private invalidationPolicyManager: InvalidationPolicyManager;
-  private cacheResultProcessor: CacheResultProcessor;
-  private entityStoreRoot: EntityStore.Root;
-  private isBroadcasting: boolean;
+  protected entityTypeMap: EntityTypeMap;
+  protected invalidationPolicyManager: InvalidationPolicyManager;
+  protected cacheResultProcessor: CacheResultProcessor;
+  protected entityStoreRoot: EntityStore.Root;
+  protected isBroadcasting: boolean;
 
   constructor(config: InvalidationPolicyCacheConfig = {}) {
     const { invalidationPolicies = {}, ...inMemoryCacheConfig } = config;
@@ -56,7 +56,7 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     });
   }
 
-  private readField<T>(
+  protected readField<T>(
     fieldNameOrOptions: string | ReadFieldOptions | undefined,
     from: StoreObject | Reference
   ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { InvalidationPolicyCache } from "./cache";
+export { InvalidationPolicyCacheAuditor } from "./audit";
 export {
   InvalidationPolicies,
   PolicyActionEntity,


### PR DESCRIPTION
Adds audit logging through the EntityTypeMap and InvalidationPolicyManager so that it is easier to debug how entities are moving in and out of the cache.