### PR TITLE
Bugfix/empty variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.0-beta3 (Dan Reynolds)
+
+- Ensure that empty field arguments are still passed as an empty object as the variables in the policy event.
+
 1.0.0-beta2 (Dan Reynolds)
 
 - Bumps to latest Apollo version (3.1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta2",
+  "version": "1.0.0-beta3",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -236,7 +236,7 @@ export class CacheResultProcessor {
           });
 
           const hasFieldArgs = (field?.arguments?.length ?? 0) > 0;
-          const fieldVariables = variables ?? hasFieldArgs ? {} : undefined;
+          const fieldVariables = variables ?? (hasFieldArgs ? {} : undefined);
 
           // Write a query to the entity type map at `write` in addition to `merge` time so that we can keep track of its variables.
           entityTypeMap.write(typename, dataId, storeFieldName, fieldVariables);

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -234,8 +234,12 @@ export class CacheResultProcessor {
             fieldName,
             variables,
           });
+
+          const hasFieldArgs = (field?.arguments?.length ?? 0) > 0;
+          const fieldVariables = variables ?? hasFieldArgs ? {} : undefined;
+
           // Write a query to the entity type map at `write` in addition to `merge` time so that we can keep track of its variables.
-          entityTypeMap.write(typename, dataId, storeFieldName, variables);
+          entityTypeMap.write(typename, dataId, storeFieldName, fieldVariables);
 
           invalidationPolicyManager.runWritePolicy(typename, {
             parent: {
@@ -243,7 +247,7 @@ export class CacheResultProcessor {
               fieldName,
               storeFieldName,
               ref: makeReference(dataId),
-              variables,
+              variables: fieldVariables,
             },
           });
         }

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -57,8 +57,8 @@ export default class InvalidationPolicyCache extends InMemoryCache {
   }
 
   protected readField<T>(
-    fieldNameOrOptions: string | ReadFieldOptions | undefined,
-    from: StoreObject | Reference
+    fieldNameOrOptions?: string | ReadFieldOptions,
+    from?: StoreObject | Reference
   ) {
     if (!fieldNameOrOptions) {
       return;

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -52,8 +52,8 @@ export type CacheOperations = {
   ) => boolean;
   modify: (options: Cache.ModifyOptions) => boolean;
   readField: (
-    fieldNameOrOptions: string | ReadFieldOptions | undefined,
-    from: StoreObject | Reference
+    fieldNameOrOptions?: string | ReadFieldOptions | undefined,
+    from?: StoreObject | Reference
   ) => StoreValue | undefined;
 };
 
@@ -65,8 +65,8 @@ export type PolicyActionCacheOperations = {
   ) => boolean;
   modify: (options: Omit<Cache.ModifyOptions, "broadcast">) => boolean;
   readField: (
-    fieldNameOrOptions: string | ReadFieldOptions | undefined,
-    from: StoreObject | Reference
+    fieldNameOrOptions?: string | ReadFieldOptions | undefined,
+    from?: StoreObject | Reference
   ) => StoreValue | undefined;
 };
 


### PR DESCRIPTION
Fields of a query that had arguments but no variables supplied would receive `undefined` variables in the policy event rather than `{}`. Since the empty object would be needed to retrieve the field and its values from the cache using an access like:

```
CreateEmployeeResponse: {
  onWrite: {
    EmployeesResponse: (
      { modify, readField },
      { fieldName, parent }
    ) => {
      // assuming the field createEmployee has empty arguments and is stored as createEmployee({})
      const createEmployeeResponse: any = readField({
        fieldName: parent.fieldName, // createEmployee
        from: parent.ref, // { __ref: "ROOT_QUERY" }
        args: parent.variables // Must be {} to read createEmployee({}) and not createEmployee
      });
    },
  },
},
```

Now, if the field the policy event is run on has arguments, we pass `{}` as the variables to the event so that it is able to access the field in the cache using the provided variables.