### PR TITLE
Feature: Default TTLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.0-beta4 (Dan Reynolds)
+
+- [BREAKING CHANGE] Adds support for a default TTL option that applies to all types
+
 1.0.0-beta3 (Dan Reynolds)
 
 - Ensure that empty field arguments are still passed as an empty object as the variables in the policy event.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta3",
+  "version": "1.0.0-beta4",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/policies/InvalidationPolicyManager.ts
+++ b/src/policies/InvalidationPolicyManager.ts
@@ -35,7 +35,7 @@ export default class InvalidationPolicyManager {
   }
 
   private activatePolicies() {
-    const { policies = {} } = this.config;
+    const { policies } = this.config;
     const { types: policyTypes = {}, timeToLive: defaultTimeToLive } = policies;
 
     return Object.keys(policyTypes).reduce<InvalidationPolicyActivation>(

--- a/src/policies/InvalidationPolicyManager.ts
+++ b/src/policies/InvalidationPolicyManager.ts
@@ -35,12 +35,16 @@ export default class InvalidationPolicyManager {
   }
 
   private activatePolicies() {
-    const { policies } = this.config;
-    return Object.keys(policies).reduce<InvalidationPolicyActivation>(
+    const { policies = {} } = this.config;
+    const { types: policyTypes = {}, timeToLive: defaultTimeToLive } = policies;
+
+    return Object.keys(policyTypes).reduce<InvalidationPolicyActivation>(
       (acc, type) => {
-        const policy = policies[type];
+        const policy = policyTypes[type];
         acc[InvalidationPolicyEvent.Read] =
-          acc[InvalidationPolicyEvent.Read] || !!policy.timeToLive;
+          acc[InvalidationPolicyEvent.Read] ||
+          !!defaultTimeToLive ||
+          !!policy.timeToLive;
         acc[InvalidationPolicyEvent.Write] =
           acc[InvalidationPolicyEvent.Write] ||
           !!policy[InvalidationPolicyLifecycleEvent.Write];
@@ -58,7 +62,7 @@ export default class InvalidationPolicyManager {
   }
 
   private getPolicy(typeName: string): InvalidationPolicy | null {
-    return this.config.policies[typeName] || null;
+    return this.config.policies?.types?.[typeName] || null;
   }
 
   private getTypePolicyForEvent(
@@ -136,7 +140,7 @@ export default class InvalidationPolicyManager {
     fieldName?: string,
     storeFieldName?: string
   ): boolean {
-    const { cacheOperations, entityTypeMap } = this.config;
+    const { cacheOperations, entityTypeMap, policies } = this.config;
     const entityId = makeEntityId(dataId, fieldName);
     const typeMapEntity = entityTypeMap.readEntityById(entityId);
 
@@ -148,12 +152,13 @@ export default class InvalidationPolicyManager {
       storeFieldName && typeMapEntity.storeFieldNames
         ? typeMapEntity.storeFieldNames.entries[storeFieldName].cacheTime
         : typeMapEntity.cacheTime;
-    const typeTimeToLive = this.getPolicy(typename)?.timeToLive;
+    const timeToLive =
+      this.getPolicy(typename)?.timeToLive || policies.timeToLive;
 
     if (
       _.isNumber(entityCacheTime) &&
-      typeTimeToLive &&
-      Date.now() > entityCacheTime + typeTimeToLive
+      timeToLive &&
+      Date.now() > entityCacheTime + timeToLive
     ) {
       return cacheOperations.evict({
         id: dataId,

--- a/src/policies/InvalidationPolicyManager.ts
+++ b/src/policies/InvalidationPolicyManager.ts
@@ -42,9 +42,7 @@ export default class InvalidationPolicyManager {
       (acc, type) => {
         const policy = policyTypes[type];
         acc[InvalidationPolicyEvent.Read] =
-          acc[InvalidationPolicyEvent.Read] ||
-          !!defaultTimeToLive ||
-          !!policy.timeToLive;
+          acc[InvalidationPolicyEvent.Read] || !!policy.timeToLive;
         acc[InvalidationPolicyEvent.Write] =
           acc[InvalidationPolicyEvent.Write] ||
           !!policy[InvalidationPolicyLifecycleEvent.Write];
@@ -54,7 +52,7 @@ export default class InvalidationPolicyManager {
         return acc;
       },
       {
-        [InvalidationPolicyEvent.Read]: false,
+        [InvalidationPolicyEvent.Read]: !!defaultTimeToLive,
         [InvalidationPolicyEvent.Write]: false,
         [InvalidationPolicyEvent.Evict]: false,
       }

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -14,7 +14,10 @@ export enum InvalidationPolicyLifecycleEvent {
 }
 
 export interface InvalidationPolicies {
-  [typeName: string]: InvalidationPolicy;
+  timeToLive?: number;
+  types?: {
+    [typeName: string]: InvalidationPolicy;
+  };
 }
 
 export interface PolicyActionFields {

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -168,10 +168,12 @@ describe("Cache", () => {
     beforeEach(() => {
       cache = new InvalidationPolicyCache({
         invalidationPolicies: {
-          DeleteEmployeesResponse: {
-            onWrite: {
-              Employee: ({ evict }, { id, fieldName }) =>
-                evict({ id, fieldName }),
+          types: {
+            DeleteEmployeesResponse: {
+              onWrite: {
+                Employee: ({ evict }, { id, fieldName }) =>
+                  evict({ id, fieldName }),
+              },
             },
           },
         },
@@ -228,15 +230,17 @@ describe("Cache", () => {
       beforeEach(() => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
-            DeleteEmployeesResponse: {
-              onWrite: {
-                Employee: (
-                  { evict, readField },
-                  { id, ref, parent: { variables } }
-                ) => {
-                  if (variables?.deleteEmployeeId === readField("id", ref)) {
-                    evict({ id });
-                  }
+            types: {
+              DeleteEmployeesResponse: {
+                onWrite: {
+                  Employee: (
+                    { evict, readField },
+                    { id, ref, parent: { variables } }
+                  ) => {
+                    if (variables?.deleteEmployeeId === readField("id", ref)) {
+                      evict({ id });
+                    }
+                  },
                 },
               },
             },
@@ -361,16 +365,18 @@ describe("Cache", () => {
     beforeEach(() => {
       cache = new InvalidationPolicyCache({
         invalidationPolicies: {
-          DeleteEmployeesResponse: {
-            onWrite: {
-              EmployeesResponse: ({ evict }, { id, fieldName }) =>
-                evict({ id, fieldName }),
+          types: {
+            DeleteEmployeesResponse: {
+              onWrite: {
+                EmployeesResponse: ({ evict }, { id, fieldName }) =>
+                  evict({ id, fieldName }),
+              },
             },
-          },
-          EmployeesResponse: {
-            onEvict: {
-              Employee: ({ evict }, { id, fieldName }) =>
-                evict({ id, fieldName }),
+            EmployeesResponse: {
+              onEvict: {
+                Employee: ({ evict }, { id, fieldName }) =>
+                  evict({ id, fieldName }),
+              },
             },
           },
         },
@@ -408,36 +414,40 @@ describe("Cache", () => {
       beforeEach(() => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
-            DeleteEmployeesResponse: {
-              onWrite: {
-                Employee: (
-                  { readField, evict },
-                  { ref, id, parent: { variables } }
-                ) => {
-                  if (variables?.deleteEmployeeId === readField("id", ref)) {
-                    evict({ id });
-                  }
+            types: {
+              DeleteEmployeesResponse: {
+                onWrite: {
+                  Employee: (
+                    { readField, evict },
+                    { ref, id, parent: { variables } }
+                  ) => {
+                    if (variables?.deleteEmployeeId === readField("id", ref)) {
+                      evict({ id });
+                    }
+                  },
                 },
               },
-            },
-            Employee: {
-              onEvict: {
-                EmployeeMessagesResponse: (
-                  { evict },
-                  { id, fieldName, variables }
-                ) => evict({ id, fieldName, args: variables }),
-                EmployeesResponse: ({ evict }, { id, fieldName, variables }) =>
-                  evict({ id, fieldName, args: variables }),
-                EmployeeMessage: (
-                  { evict, readField },
-                  { ref, id, parent }
-                ) => {
-                  if (
-                    readField("id", parent.ref) ===
-                    readField("employee_id", ref)
-                  ) {
-                    evict({ id });
-                  }
+              Employee: {
+                onEvict: {
+                  EmployeeMessagesResponse: (
+                    { evict },
+                    { id, fieldName, variables }
+                  ) => evict({ id, fieldName, args: variables }),
+                  EmployeesResponse: (
+                    { evict },
+                    { id, fieldName, variables }
+                  ) => evict({ id, fieldName, args: variables }),
+                  EmployeeMessage: (
+                    { evict, readField },
+                    { ref, id, parent }
+                  ) => {
+                    if (
+                      readField("id", parent.ref) ===
+                      readField("employee_id", ref)
+                    ) {
+                      evict({ id });
+                    }
+                  },
                 },
               },
             },
@@ -500,14 +510,20 @@ describe("Cache", () => {
     beforeEach(() => {
       cache = new InvalidationPolicyCache({
         invalidationPolicies: {
-          Employee: {
-            onEvict: {
-              EmployeeMessage: ({ evict, readField }, { id, ref, parent }) => {
-                if (
-                  readField("employee_id", ref) === readField("id", parent.ref)
-                ) {
-                  evict({ id });
-                }
+          types: {
+            Employee: {
+              onEvict: {
+                EmployeeMessage: (
+                  { evict, readField },
+                  { id, ref, parent }
+                ) => {
+                  if (
+                    readField("employee_id", ref) ===
+                    readField("id", parent.ref)
+                  ) {
+                    evict({ id });
+                  }
+                },
               },
             },
           },
@@ -614,26 +630,31 @@ describe("Cache", () => {
       beforeEach(() => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
-            CreateEmployeeResponse: {
-              onWrite: {
-                EmployeesResponse: (
-                  { modify, readField },
-                  { storeFieldName, parent }
-                ) => {
-                  const createEmployeeResponse: any = readField(
-                    parent.storeFieldName,
-                    parent.ref
-                  );
-                  modify({
-                    fields: {
-                      [storeFieldName!]: (existing) => {
-                        return {
-                          ...existing,
-                          data: [...existing.data, createEmployeeResponse.data],
-                        };
+            types: {
+              CreateEmployeeResponse: {
+                onWrite: {
+                  EmployeesResponse: (
+                    { modify, readField },
+                    { storeFieldName, parent }
+                  ) => {
+                    const createEmployeeResponse: any = readField(
+                      parent.storeFieldName,
+                      parent.ref
+                    );
+                    modify({
+                      fields: {
+                        [storeFieldName!]: (existing) => {
+                          return {
+                            ...existing,
+                            data: [
+                              ...existing.data,
+                              createEmployeeResponse.data,
+                            ],
+                          };
+                        },
                       },
-                    },
-                  });
+                    });
+                  },
                 },
               },
             },
@@ -858,23 +879,25 @@ describe("Cache", () => {
       beforeEach(() => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
-            Employee: {
-              onWrite: {
-                EmployeeMessage: (
-                  { modify, readField },
-                  { id, ref, parent }
-                ) => {
-                  if (
-                    readField("employee_id", ref) ===
-                    readField("id", parent.ref)
-                  ) {
-                    modify({
-                      id,
-                      fields: {
-                        employee_message: () => "je pense donc je suis",
-                      },
-                    });
-                  }
+            types: {
+              Employee: {
+                onWrite: {
+                  EmployeeMessage: (
+                    { modify, readField },
+                    { id, ref, parent }
+                  ) => {
+                    if (
+                      readField("employee_id", ref) ===
+                      readField("id", parent.ref)
+                    ) {
+                      modify({
+                        id,
+                        fields: {
+                          employee_message: () => "je pense donc je suis",
+                        },
+                      });
+                    }
+                  },
                 },
               },
             },
@@ -954,19 +977,21 @@ describe("Cache", () => {
         beforeEach(() => {
           cache = new InvalidationPolicyCache({
             invalidationPolicies: {
-              DeleteEmployeesResponse: {
-                onWrite: {
-                  EmployeesResponse: ({ modify }, { storeFieldName }) => {
-                    modify({
-                      fields: {
-                        [storeFieldName!]: (existing) => {
-                          return {
-                            ...existing,
-                            data: [],
-                          };
+              types: {
+                DeleteEmployeesResponse: {
+                  onWrite: {
+                    EmployeesResponse: ({ modify }, { storeFieldName }) => {
+                      modify({
+                        fields: {
+                          [storeFieldName!]: (existing) => {
+                            return {
+                              ...existing,
+                              data: [],
+                            };
+                          },
                         },
-                      },
-                    });
+                      });
+                    },
                   },
                 },
               },
@@ -1050,26 +1075,28 @@ describe("Cache", () => {
         beforeEach(() => {
           cache = new InvalidationPolicyCache({
             invalidationPolicies: {
-              Employee: {
-                onWrite: {
-                  EmployeeMessagesResponse: (
-                    { modify, readField },
-                    { storeFieldName, parent }
-                  ) => {
-                    modify({
-                      fields: {
-                        [storeFieldName!]: (existing) => {
-                          return {
-                            ...existing,
-                            data: existing.data.filter(
-                              (employeeMessage: any) =>
-                                readField("employee_id", employeeMessage) ===
-                                readField("id", parent.ref)
-                            ),
-                          };
+              types: {
+                Employee: {
+                  onWrite: {
+                    EmployeeMessagesResponse: (
+                      { modify, readField },
+                      { storeFieldName, parent }
+                    ) => {
+                      modify({
+                        fields: {
+                          [storeFieldName!]: (existing) => {
+                            return {
+                              ...existing,
+                              data: existing.data.filter(
+                                (employeeMessage: any) =>
+                                  readField("employee_id", employeeMessage) ===
+                                  readField("id", parent.ref)
+                              ),
+                            };
+                          },
                         },
-                      },
-                    });
+                      });
+                    },
                   },
                 },
               },
@@ -1123,23 +1150,25 @@ describe("Cache", () => {
       beforeEach(() => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
-            Employee: {
-              onWrite: {
-                EmployeeMessage: (
-                  { modify, readField },
-                  { ref, id, parent }
-                ) => {
-                  if (
-                    readField("employee_id", ref) ===
-                    readField("id", parent.ref)
-                  ) {
-                    modify({
-                      id,
-                      fields: {
-                        employee_message: () => "Cogito ergo sum",
-                      },
-                    });
-                  }
+            types: {
+              Employee: {
+                onWrite: {
+                  EmployeeMessage: (
+                    { modify, readField },
+                    { ref, id, parent }
+                  ) => {
+                    if (
+                      readField("employee_id", ref) ===
+                      readField("id", parent.ref)
+                    ) {
+                      modify({
+                        id,
+                        fields: {
+                          employee_message: () => "Cogito ergo sum",
+                        },
+                      });
+                    }
+                  },
                 },
               },
             },
@@ -1205,35 +1234,37 @@ describe("Cache", () => {
     beforeEach(() => {
       cache = new InvalidationPolicyCache({
         invalidationPolicies: {
-          DeleteEmployeesResponse: {
-            onWrite: {
-              EmployeesResponse: ({ modify }, { storeFieldName }) => {
-                modify({
-                  fields: {
-                    [storeFieldName!]: (existing) => {
-                      return {
-                        ...existing,
-                        data: [],
-                      };
+          types: {
+            DeleteEmployeesResponse: {
+              onWrite: {
+                EmployeesResponse: ({ modify }, { storeFieldName }) => {
+                  modify({
+                    fields: {
+                      [storeFieldName!]: (existing) => {
+                        return {
+                          ...existing,
+                          data: [],
+                        };
+                      },
                     },
-                  },
-                });
+                  });
+                },
               },
             },
-          },
-          EmployeesResponse: {
-            onWrite: {
-              EmployeeMessagesResponse: ({ modify }, { storeFieldName }) => {
-                modify({
-                  fields: {
-                    [storeFieldName!]: (existing) => {
-                      return {
-                        ...existing,
-                        data: [],
-                      };
+            EmployeesResponse: {
+              onWrite: {
+                EmployeeMessagesResponse: ({ modify }, { storeFieldName }) => {
+                  modify({
+                    fields: {
+                      [storeFieldName!]: (existing) => {
+                        return {
+                          ...existing,
+                          data: [],
+                        };
+                      },
                     },
-                  },
-                });
+                  });
+                },
               },
             },
           },
@@ -1313,8 +1344,10 @@ describe("Cache", () => {
         test("should not evict the query from the cache", () => {
           cache = new InvalidationPolicyCache({
             invalidationPolicies: {
-              EmployeesResponse: {
-                timeToLive,
+              types: {
+                EmployeesResponse: {
+                  timeToLive,
+                },
               },
             },
           });
@@ -1357,8 +1390,10 @@ describe("Cache", () => {
           beforeEach(() => {
             cache = new InvalidationPolicyCache({
               invalidationPolicies: {
-                Employee: {
-                  timeToLive,
+                types: {
+                  Employee: {
+                    timeToLive,
+                  },
                 },
               },
             });
@@ -1419,8 +1454,10 @@ describe("Cache", () => {
           beforeEach(() => {
             cache = new InvalidationPolicyCache({
               invalidationPolicies: {
-                Employee: {
-                  timeToLive,
+                types: {
+                  Employee: {
+                    timeToLive,
+                  },
                 },
               },
             });
@@ -1473,8 +1510,10 @@ describe("Cache", () => {
           test("should not evict the expired query field from the cache", () => {
             cache = new InvalidationPolicyCache({
               invalidationPolicies: {
-                EmployeesResponse: {
-                  timeToLive,
+                types: {
+                  EmployeesResponse: {
+                    timeToLive,
+                  },
                 },
               },
             });
@@ -1511,11 +1550,13 @@ describe("Cache", () => {
           beforeEach(() => {
             cache = new InvalidationPolicyCache({
               invalidationPolicies: {
-                EmployeesResponse: {
-                  timeToLive,
-                },
-                EmployeeMessagesResponse: {
-                  timeToLive,
+                types: {
+                  EmployeesResponse: {
+                    timeToLive,
+                  },
+                  EmployeeMessagesResponse: {
+                    timeToLive,
+                  },
                 },
               },
             });
@@ -1606,8 +1647,10 @@ describe("Cache", () => {
             test("should evict the expired query fields with matching variables from the cache", () => {
               cache = new InvalidationPolicyCache({
                 invalidationPolicies: {
-                  EmployeesResponse: {
-                    timeToLive,
+                  types: {
+                    EmployeesResponse: {
+                      timeToLive,
+                    },
                   },
                 },
               });
@@ -1658,8 +1701,10 @@ describe("Cache", () => {
             test("should evict the expired query fields with fields matching the supported subset of variables", () => {
               cache = new InvalidationPolicyCache({
                 invalidationPolicies: {
-                  EmployeesResponse: {
-                    timeToLive,
+                  types: {
+                    EmployeesResponse: {
+                      timeToLive,
+                    },
                   },
                 },
               });
@@ -1692,8 +1737,10 @@ describe("Cache", () => {
             test("should evict the expired query with empty variables", () => {
               cache = new InvalidationPolicyCache({
                 invalidationPolicies: {
-                  EmployeesResponse: {
-                    timeToLive,
+                  types: {
+                    EmployeesResponse: {
+                      timeToLive,
+                    },
                   },
                 },
               });
@@ -1761,8 +1808,10 @@ describe("Cache", () => {
               let queryResult: any;
               cache = new InvalidationPolicyCache({
                 invalidationPolicies: {
-                  EmployeesResponse: {
-                    timeToLive,
+                  types: {
+                    EmployeesResponse: {
+                      timeToLive,
+                    },
                   },
                 },
               });
@@ -1795,8 +1844,10 @@ describe("Cache", () => {
           test("should not evict the query field from the cache", () => {
             cache = new InvalidationPolicyCache({
               invalidationPolicies: {
-                EmployeesResponse: {
-                  timeToLive,
+                types: {
+                  EmployeesResponse: {
+                    timeToLive,
+                  },
                 },
               },
             });
@@ -1846,11 +1897,13 @@ describe("Cache", () => {
           beforeEach(() => {
             cache = new InvalidationPolicyCache({
               invalidationPolicies: {
-                EmployeesResponse: {
-                  timeToLive,
-                },
-                Employee: {
-                  timeToLive,
+                types: {
+                  EmployeesResponse: {
+                    timeToLive,
+                  },
+                  Employee: {
+                    timeToLive,
+                  },
                 },
               },
             });
@@ -1900,11 +1953,13 @@ describe("Cache", () => {
           beforeEach(() => {
             cache = new InvalidationPolicyCache({
               invalidationPolicies: {
-                EmployeesResponse: {
-                  timeToLive,
-                },
-                Employee: {
-                  timeToLive,
+                types: {
+                  EmployeesResponse: {
+                    timeToLive,
+                  },
+                  Employee: {
+                    timeToLive,
+                  },
                 },
               },
             });
@@ -1944,8 +1999,10 @@ describe("Cache", () => {
         beforeEach(() => {
           cache = new InvalidationPolicyCache({
             invalidationPolicies: {
-              EmployeesResponse: {
-                timeToLive,
+              types: {
+                EmployeesResponse: {
+                  timeToLive,
+                },
               },
             },
           });
@@ -1989,8 +2046,10 @@ describe("Cache", () => {
         test("should not evict the query from the cache", () => {
           cache = new InvalidationPolicyCache({
             invalidationPolicies: {
-              Employee: {
-                timeToLive,
+              types: {
+                Employee: {
+                  timeToLive,
+                },
               },
             },
           });
@@ -2032,8 +2091,10 @@ describe("Cache", () => {
         test("should evict the normalized object from the cache", () => {
           cache = new InvalidationPolicyCache({
             invalidationPolicies: {
-              Employee: {
-                timeToLive,
+              types: {
+                Employee: {
+                  timeToLive,
+                },
               },
             },
           });

--- a/tests/InvalidationPolicyManager.test.ts
+++ b/tests/InvalidationPolicyManager.test.ts
@@ -48,10 +48,12 @@ describe("InvalidationPolicyManager", () => {
       employeePolicyActionSpy = jest.fn();
       employeesResponsePolicyActionSpy = jest.fn();
       policies = {
-        CreateEmployeeResponse: {
-          onEvict: {
-            Employee: employeePolicyActionSpy,
-            EmployeesResponse: employeesResponsePolicyActionSpy,
+        types: {
+          CreateEmployeeResponse: {
+            onEvict: {
+              Employee: employeePolicyActionSpy,
+              EmployeesResponse: employeesResponsePolicyActionSpy,
+            },
           },
         },
       };
@@ -135,15 +137,17 @@ describe("InvalidationPolicyManager", () => {
   describe("#activatePolicies", () => {
     test("should activate all policies with config options", () => {
       policies = {
-        Employee: {
-          timeToLive: 5,
-        },
-        EmployeeResponse: {
-          onWrite: {
-            Employee: () => {},
+        types: {
+          Employee: {
+            timeToLive: 5,
           },
-          onEvict: {
-            Employee: () => {},
+          EmployeeResponse: {
+            onWrite: {
+              Employee: () => {},
+            },
+            onEvict: {
+              Employee: () => {},
+            },
           },
         },
       };
@@ -166,8 +170,10 @@ describe("InvalidationPolicyManager", () => {
 
     test("should not activate policies without config options", () => {
       policies = {
-        Employee: {},
-        EmployeeResponse: {},
+        types: {
+          Employee: {},
+          EmployeeResponse: {},
+        },
       };
       invalidationPolicyManager = new InvalidationPolicyManager({
         entityTypeMap,


### PR DESCRIPTION
Closes: https://github.com/NerdWalletOSS/apollo-invalidation-policies/issues/4

Adds support for a default `timeToLive` value that will be applied to all types in the cache. It can be specified as a top level field on the invalidation policies:

```
const cache = new InvalidationPolicyCache({
  typePolicies: {...},
  invalidationPolicies: {
    timeToLive: Number;
    types: {
      Typename: {
        timeToLive: Number,
        PolicyEvent: {
          Typename: (PolicyActionCacheOperation, PolicyActionEntity) => {}
        },
      }
    }
  }
});
```

A `timeToLive` on a particular type overrides the top level `timeToLive`.

The policies for types have been moved under a `types` key to group them separately from the new top-level config property space similarly to how the `typePolicies` from Apollo group the policies for fields under a `fields` key: https://www.apollographql.com/docs/react/caching/cache-configuration/#typepolicy-fields

This is a breaking change, but given the lib is in beta, it is expected that during this period breaking changes can be made.