### PR TITLE
Feature/renewal policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.0.-beta5 (Dan Reynolds)
+
+- Adds support for a `renewalPolicy` type and global config option for specifying how type TTLs should be renewed on write vs access
+- Adds the `expire` API for evicting all entities that have expired in the cache based on their type's or the global TTL.
+
 1.0.0-beta4 (Dan Reynolds)
 
 - [BREAKING CHANGE] Adds support for a default TTL option that applies to all types

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ const cache = new InvalidationPolicyCache({
   typePolicies: {...},
   invalidationPolicies: {
     timeToLive: Number;
+    renewalPolicy: RenewalPolicy;
     types: {
       Typename: {
         timeToLive: Number,
+        renewalPolicy: RenewalPolicy,
         PolicyEvent: {
           Typename: (PolicyActionCacheOperation, PolicyActionEntity) => {}
         },
@@ -30,10 +32,18 @@ const cache = new InvalidationPolicyCache({
 });
 ```
 
-| Config         | Description                                                                                | Required | Default |
-| ---------------| -------------------------------------------------------------------------------------------|----------|---------|
-| `timeToLive`   | The global time to live in milliseconds for all types in the cache                         | false    | None    |
-| `types`        | The types for which invalidation policies have been defined                                | false    | None    |
+| Config          | Description                                                                                | Required | Default   |
+| ----------------| -------------------------------------------------------------------------------------------|----------|-----------|
+| `timeToLive`    | The global time to live in milliseconds for all types in the cache                         | false    | None      |
+| `types`         | The types for which invalidation policies have been defined                                | false    | None      |
+| `renewalPolicy` | The policy for renewing an entity's time to live in the cache                              | false    | WriteOnly |
+
+### Renewal policies:
+
+* **AccessOnly** - After first write, the entity in the cache will renew its TTL on read
+* **AccessAndWrite** - After first write, the entity will renew its TTL on read or write
+* **WriteOnly** - After first write, the entity in the cache will renew its TTL on write
+* **None** - After first write, the entity in the cache will never renew its TTL on reads or writes.
 
 | Policy Event   | Description                                                                                | Required |
 | ---------------| -------------------------------------------------------------------------------------------|----------|

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ const cache = new InvalidationPolicyCache({
 | `modify`                      | `modify` API from Apollo cache     |
 | `readField`                   | `readField` API from Apollo cache  |
 
+| Extended cache API | Description                                                                                | Return Type                                           |
+| -------------------| -------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `expire`           | Evicts all expired entities from the cache based on their type's or the global timeToLive. | String[] - List of entity IDs evicted from the cache. |
+
 | Policy Action Entity | Description                                             | Type               | Example                                                                                     |
 | ---------------------| --------------------------------------------------------|--------------------| --------------------------------------------------------------------------------------------|
 | `id`                 | The id of the entity in the Apollo cache                | string             | `Employee:1`, `ROOT_QUERY`                                                                  |

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -34,7 +34,9 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     // @ts-ignore
     this.entityStoreRoot = this.data;
     this.isBroadcasting = false;
-    this.entityTypeMap = new EntityTypeMap();
+    this.entityTypeMap = new EntityTypeMap({
+      policies: invalidationPolicies,
+    });
     new EntityStoreWatcher({
       entityStore: this.entityStoreRoot,
       entityTypeMap: this.entityTypeMap,
@@ -246,7 +248,7 @@ export default class InvalidationPolicyCache extends InMemoryCache {
 
     // Diff calls made by `broadcastWatches` should not trigger the read policy
     // as these are internal reads not reflective of client action and can lead to recursive recomputation of cached data which is an error.
-    // Instead, diffs swill trigger the read policies for client-based reads like `readCache` invocations from watched queries outside
+    // Instead, diffs will trigger the read policies for client-based reads like `readCache` invocations from watched queries outside
     // the scope of broadcasts.
     if (
       !this.invalidationPolicyManager.isPolicyActive(

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -34,9 +34,7 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     // @ts-ignore
     this.entityStoreRoot = this.data;
     this.isBroadcasting = false;
-    this.entityTypeMap = new EntityTypeMap({
-      policies: invalidationPolicies,
-    });
+    this.entityTypeMap = new EntityTypeMap();
     new EntityStoreWatcher({
       entityStore: this.entityStoreRoot,
       entityTypeMap: this.entityTypeMap,
@@ -155,9 +153,12 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     // Do not trigger a write policy if the current write is being applied to an optimistic data layer since
     // the policy will later be applied when the server data response is received.
     if (
-      !this.invalidationPolicyManager.isPolicyActive(
+      (!this.invalidationPolicyManager.isPolicyActive(
         InvalidationPolicyEvent.Write
-      ) ||
+      ) &&
+        !this.invalidationPolicyManager.isPolicyActive(
+          InvalidationPolicyEvent.Read
+        )) ||
       !this.isOperatingOnRootData()
     ) {
       return writeResult;

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -216,6 +216,47 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     return super.evict(options);
   }
 
+  // Evicts all expired entities whose cache time exceeds their type's timeToLive or as a fallback
+  // the global timeToLive if specified. Returns a list of entity IDs removed from the cache.
+  expire() {
+    const { entitiesById } = this.entityTypeMap.extract();
+    const expiredEntityIds: string[] = [];
+
+    Object.keys(entitiesById).forEach((entityId) => {
+      const entity = entitiesById[entityId];
+      const { storeFieldNames, dataId, fieldName, typename } = entity;
+
+      if (isQuery(dataId) && storeFieldNames) {
+        Object.keys(storeFieldNames.entries).forEach((storeFieldName) => {
+          const evicted = this.invalidationPolicyManager.runReadPolicy(
+            typename,
+            dataId,
+            fieldName,
+            storeFieldName
+          );
+          if (evicted) {
+            expiredEntityIds.push(makeEntityId(dataId, storeFieldName));
+          }
+        });
+      } else {
+        const evicted = this.invalidationPolicyManager.runReadPolicy(
+          typename,
+          dataId,
+          fieldName
+        );
+        if (evicted) {
+          expiredEntityIds.push(makeEntityId(dataId));
+        }
+      }
+    });
+
+    if (expiredEntityIds.length > 0) {
+      this.broadcastWatches();
+    }
+
+    return expiredEntityIds;
+  }
+
   read<T>(options: Cache.ReadOptions<any>): T | null {
     const result = super.read<T>(options);
 
@@ -287,10 +328,10 @@ export default class InvalidationPolicyCache extends InMemoryCache {
     const extractedCache = super.extract(optimistic);
 
     if (withInvalidation) {
+      // The entitiesById are sufficient alone for reconstructing the type map, so to
+      // minimize payload size only inject the entitiesById object into the extracted cache
       extractedCache.invalidation = _.pick(
         this.entityTypeMap.extract(),
-        // The entitiesById are sufficient alone for reconstructing the type map, so to
-        // minimize payload size only inject the entitiesById object into the extracted cache
         "entitiesById"
       );
     }

--- a/src/entity-store/EntityTypeMap.ts
+++ b/src/entity-store/EntityTypeMap.ts
@@ -225,10 +225,10 @@ export default class EntityTypeMap {
 
   extract(): ExtractedTypeMap {
     const { entitiesById, entitiesByType } = this;
-    return _.cloneDeep({
+    return {
       entitiesById,
       entitiesByType,
-    });
+    };
   }
 
   clear() {

--- a/src/entity-store/types.ts
+++ b/src/entity-store/types.ts
@@ -14,7 +14,7 @@ export interface TypeMapEntity {
     __size: number;
     entries: {
       [index: string]: {
-        cacheTime: number;
+        cacheTime?: number;
         variables?: Record<string, any>;
       };
     };

--- a/src/entity-store/types.ts
+++ b/src/entity-store/types.ts
@@ -1,4 +1,9 @@
 import { NormalizedCacheObject } from "@apollo/client";
+import { InvalidationPolicies } from "../policies/types";
+
+export interface EntityTypeMapConfig {
+  policies: InvalidationPolicies;
+}
 
 export interface TypeMapEntity {
   dataId: string;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import { InvalidationPolicies, RenewalPolicy } from "./policies/types";
 
 export function isQuery(dataId: string) {
   return dataId === "ROOT_QUERY" || dataId === "ROOT_MUTATION";
@@ -26,3 +27,14 @@ export function makeEntityId(
 // https://github.com/apollographql/apollo-client/blob/master/src/utilities/common/maybeDeepFreeze.ts#L20:L20
 export const maybeDeepClone = (obj: any) =>
   _.isPlainObject(obj) && Object.isFrozen(obj) ? _.cloneDeep(obj) : obj;
+
+export const getRenewalPolicyForType = (
+  policies: InvalidationPolicies,
+  typename: string
+) => {
+  return (
+    policies.types?.[typename]?.renewalPolicy ??
+    policies.renewalPolicy ??
+    RenewalPolicy.WriteOnly
+  );
+};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import { InvalidationPolicies, RenewalPolicy } from "./policies/types";
 
 export function isQuery(dataId: string) {
   return dataId === "ROOT_QUERY" || dataId === "ROOT_MUTATION";
@@ -27,14 +26,3 @@ export function makeEntityId(
 // https://github.com/apollographql/apollo-client/blob/master/src/utilities/common/maybeDeepFreeze.ts#L20:L20
 export const maybeDeepClone = (obj: any) =>
   _.isPlainObject(obj) && Object.isFrozen(obj) ? _.cloneDeep(obj) : obj;
-
-export const getRenewalPolicyForType = (
-  policies: InvalidationPolicies,
-  typename: string
-) => {
-  return (
-    policies.types?.[typename]?.renewalPolicy ??
-    policies.renewalPolicy ??
-    RenewalPolicy.WriteOnly
-  );
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export {
   InvalidationPolicies,
   PolicyActionEntity,
   PolicyActionFields,
+  RenewalPolicy,
 } from "./policies/types";
 export { InvalidationPolicyCacheConfig } from "./cache/types";

--- a/src/policies/InvalidationPolicyManager.ts
+++ b/src/policies/InvalidationPolicyManager.ts
@@ -10,6 +10,7 @@ import {
 } from "./types";
 import { makeEntityId } from "../helpers";
 import { makeReference } from "@apollo/client";
+import { RenewalPolicy } from "./types";
 
 /**
  * Executes invalidation policies for types when they are modified, evicted or read from the cache.
@@ -114,6 +115,15 @@ export default class InvalidationPolicyManager {
         }
       });
     });
+  }
+
+  getRenewalPolicyForType(typename: string) {
+    const { policies } = this.config;
+    return (
+      policies.types?.[typename]?.renewalPolicy ??
+      policies.renewalPolicy ??
+      RenewalPolicy.WriteOnly
+    );
   }
 
   runWritePolicy(typeName: string, policyMeta: PolicyActionMeta) {

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -13,8 +13,16 @@ export enum InvalidationPolicyLifecycleEvent {
   Evict = "onEvict",
 }
 
+export enum RenewalPolicy {
+  AccessOnly = "access-only",
+  AccessAndWrite = "access-and-write",
+  WriteOnly = "write-only",
+  None = "none",
+}
+
 export interface InvalidationPolicies {
   timeToLive?: number;
+  renewalPolicy?: RenewalPolicy;
   types?: {
     [typeName: string]: InvalidationPolicy;
   };
@@ -45,6 +53,7 @@ export type InvalidationPolicy = {
   };
 } & {
   timeToLive?: number;
+  renewalPolicy?: RenewalPolicy;
 };
 
 export type CacheOperations = {

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -2244,7 +2244,7 @@ describe("Cache", () => {
       });
     });
 
-    describe("with an AccessOnly refresh policy", () => {
+    describe("with an AccessOnly renewal policy", () => {
       test("should renew the type on read and not evict entities", () => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
@@ -2316,7 +2316,7 @@ describe("Cache", () => {
       });
     });
 
-    describe("with an AccessAndWrite refresh policy", () => {
+    describe("with an AccessAndWrite renewal policy", () => {
       test("should renew the type on read and not evict entities", () => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
@@ -2388,7 +2388,7 @@ describe("Cache", () => {
       });
     });
 
-    describe("with a WriteOnly refresh policy", () => {
+    describe("with a WriteOnly renewal policy", () => {
       test("should evict the expired entities on write", () => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {
@@ -2436,7 +2436,7 @@ describe("Cache", () => {
       });
     });
 
-    describe("with a None refresh policy", () => {
+    describe("with a None renewal policy", () => {
       test("should evict the expired entities on write", () => {
         cache = new InvalidationPolicyCache({
           invalidationPolicies: {

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -2491,6 +2491,119 @@ describe("Cache", () => {
     });
   });
 
+  describe("#expire", () => {
+    let dateNowSpy: any;
+
+    describe("with all expired entities", () => {
+      test("should evict all expired entities from the cache", () => {
+        cache = new InvalidationPolicyCache({
+          invalidationPolicies: {
+            timeToLive: 100,
+          },
+        });
+        dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(0);
+        cache.writeQuery({
+          query: employeesAndMessagesQuery,
+          data: employeesAndMessagesResponse,
+        });
+        dateNowSpy.mockRestore();
+        dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(101);
+
+        expect(cache.extract(true, false)).toEqual({
+          [employee.toRef()]: employee,
+          [employee2.toRef()]: employee2,
+          [employeeMessage.toRef()]: employeeMessage,
+          [employeeMessage2.toRef()]: employeeMessage2,
+          ROOT_QUERY: {
+            __typename: "Query",
+            employees: {
+              __typename: "EmployeesResponse",
+              data: [{ __ref: employee.toRef() }, { __ref: employee2.toRef() }],
+            },
+            employeeMessages: {
+              __typename: "EmployeeMessagesResponse",
+              data: [
+                { __ref: employeeMessage.toRef() },
+                { __ref: employeeMessage2.toRef() },
+              ],
+            },
+          },
+        });
+        const expiredEntityIds = cache.expire();
+        expect(expiredEntityIds).toEqual([
+          employee.toRef(),
+          employee2.toRef(),
+          employeeMessage.toRef(),
+          employeeMessage2.toRef(),
+          "ROOT_QUERY.employees",
+          "ROOT_QUERY.employeeMessages",
+        ]);
+        expect(cache.extract(true, false)).toEqual({
+          ROOT_QUERY: {
+            __typename: "Query",
+          },
+        });
+      });
+    });
+
+    describe("with partial expired entities", () => {
+      test("should evict all expired entities from the cache", () => {
+        cache = new InvalidationPolicyCache({
+          invalidationPolicies: {
+            timeToLive: 100,
+            types: {
+              Employee: {
+                timeToLive: 150,
+              },
+            },
+          },
+        });
+        dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(0);
+        cache.writeQuery({
+          query: employeesAndMessagesQuery,
+          data: employeesAndMessagesResponse,
+        });
+        dateNowSpy.mockRestore();
+        dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(101);
+
+        expect(cache.extract(true, false)).toEqual({
+          [employee.toRef()]: employee,
+          [employee2.toRef()]: employee2,
+          [employeeMessage.toRef()]: employeeMessage,
+          [employeeMessage2.toRef()]: employeeMessage2,
+          ROOT_QUERY: {
+            __typename: "Query",
+            employees: {
+              __typename: "EmployeesResponse",
+              data: [{ __ref: employee.toRef() }, { __ref: employee2.toRef() }],
+            },
+            employeeMessages: {
+              __typename: "EmployeeMessagesResponse",
+              data: [
+                { __ref: employeeMessage.toRef() },
+                { __ref: employeeMessage2.toRef() },
+              ],
+            },
+          },
+        });
+        const expiredEntityIds = cache.expire();
+        expect(expiredEntityIds).toEqual([
+          employeeMessage.toRef(),
+          employeeMessage2.toRef(),
+          "ROOT_QUERY.employees",
+          "ROOT_QUERY.employeeMessages",
+        ]);
+        expect(cache.extract(true, false)).toEqual({
+          [employee.toRef()]: employee,
+          [employee2.toRef()]: employee2,
+          ROOT_QUERY: {
+            __typename: "Query",
+          },
+        });
+      });
+    });
+  });
+
   describe("#extract", () => {
     describe("without invalidation extracted", () => {
       beforeEach(() => {


### PR DESCRIPTION
Closes #6.

Adds a new global and type-specific `renewalPolicy` property used to control when an entity's timeToLive is refreshed in the cache. Defaults to `WriteOnly` so that every time an entity is written into the cache it will be valid until that time + its TTL and will be evicted when read after its TTL has expired. This was how TTLs operated prior to this change and preserves that behavior.

All options are:

1. AccessOnly - After first write, the entity in the cache will renew its TTL on read
2. AccessAndWrite - After first write, the entity will renew its TTL on read or write
3. WriteOnly - After first write, the entity in the cache will renew its TTL on write
4. None - After first write, the entity in the cache will never renew its TTL on reads or writes.

Additionally introduces a new `cache.expire` API to evict all currently expired entities in the cache. This is then the only way to evict expired entities with an `AccessOnly` or `AccessAndWrite` policy and is useful if clients wants to clean up their expired entities periodically rather than lazily on reads like the default behavior provides.

Usage of the renewal policies look like:

```javascript
import { InvalidationPolicyCache, RenewalPolicy } from 'apollo-invalidation-policies';
const cache = new InvalidationPolicyCache({
  typePolicies: {...},
  invalidationPolicies: {
    timeToLive: 10000;
    types: {
      Employee: {
        renewalPolicy: RenewalPolicy.AccessAndWrite,
      }
    }
  }
});
```

More descriptions of usage in the Readme: https://github.com/NerdWalletOSS/apollo-invalidation-policies/pull/9/files#diff-04c6e90faac2675aa89e2176d2eec7d8