### PR TITLE
add policy action storage object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 1.0.0-beta6 (Dan Reynolds)
 
-- Adds a `storage` dictionary by unique `storeFieldName` for queries or `ID` for normalized entities in the policy action object so that arbitrary meta information can be stored across
-  multiple policy action invocations.
+- Adds a `storage` dictionary by unique `storeFieldName` for queries or `ID` for normalized entities in the policy action object so that arbitrary meta information can be stored across multiple policy action invocations.
 
 1.0.0-beta5 (Dan Reynolds)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-1.0.0.-beta5 (Dan Reynolds)
+1.0.0-beta6 (Dan Reynolds)
+
+- Adds a `storage` dictionary by unique `storeFieldName` for queries or `ID` for normalized entities in the policy action object so that arbitrary meta information can be stored across
+  multiple policy action invocations.
+
+1.0.0-beta5 (Dan Reynolds)
 
 - Adds support for a `renewalPolicy` type and global config option for specifying how type TTLs should be renewed on write vs access
 - Adds the `expire` API for evicting all entities that have expired in the cache based on their type's or the global TTL.

--- a/README.md
+++ b/README.md
@@ -61,13 +61,14 @@ const cache = new InvalidationPolicyCache({
 | `expire`           | Evicts all expired entities from the cache based on their type's or the global timeToLive. | String[] - List of entity IDs evicted from the cache. |
 
 | Policy Action Entity | Description                                             | Type               | Example                                                                                     |
-| ---------------------| --------------------------------------------------------|--------------------| --------------------------------------------------------------------------------------------|
-| `id`                 | The id of the entity in the Apollo cache                | string             | `Employee:1`, `ROOT_QUERY`                                                                  |
-| `ref`                | The reference object for the entity in the Apollo cache | Reference          | `{ __ref: 'Employee:1' }`, `{ __ref: 'ROOT_QUERY' }`                                        |
-| `fieldName`          | The field for the entity in the Apollo cache            | string?            | `employees`                                                                                 |
-| `storeFieldName`     | The `fieldName` combined with its distinct variables    | string?            | `employees({ location: 'US' })`                                                             |
-| `variables`          | The variables the entity was written with               | Object?            | `{ location: 'US' }`                                                                        |
-| `parent`             | The parent entity that triggered the PolicyEvent        | PolicyActionEntity | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
+| ---------------------| --------------------------------------------------------|--------------------| ---------------------------------------------------------------------------------------------|
+| `id`                 | The id of the entity in the Apollo cache                | string              | `Employee:1`, `ROOT_QUERY`                                                                  |
+| `ref`                | The reference object for the entity in the Apollo cache | Reference           | `{ __ref: 'Employee:1' }`, `{ __ref: 'ROOT_QUERY' }`                                        |
+| `fieldName`          | The field for the entity in the Apollo cache            | string?             | `employees`                                                                                 |
+| `storeFieldName`     | The `fieldName` combined with its distinct variables    | string?             | `employees({ location: 'US' })`                                                             |
+| `variables`          | The variables the entity was written with               | Object?             | `{ location: 'US' }`                                                                        |
+| `storage`            | An object for storing unique entity metadata across policy action invocations | Object            | `{}`                                                                        |
+| `parent`             | The parent entity that triggered the PolicyEvent        | PolicyActionEntity  | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
 
 ```javascript
 import { ApolloClient, InMemoryCache } from "@apollo/client";

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -28,18 +28,21 @@ export interface InvalidationPolicies {
   };
 }
 
+export type PolicyActionStorage = Record<string, Record<string, any>>;
+
 export interface PolicyActionFields {
   id: string;
   ref: Reference;
   fieldName?: string;
   storeFieldName?: string;
+  storage: PolicyActionStorage,
   variables?: Record<string, any>;
 }
 
 export type PolicyActionEntity = PolicyActionFields & PolicyActionMeta;
 
 export interface PolicyActionMeta {
-  parent: PolicyActionFields;
+  parent: Omit<PolicyActionFields, 'storage'>;
 }
 
 export type PolicyAction = (


### PR DESCRIPTION
Adds a new `storage` property to policy actions so that they can persist metadata across multiple policy action runs. This storage object is modeled after the Apollo 3 field policies storage option here: https://www.apollographql.com/docs/react/caching/cache-field-behavior/#fieldpolicy-api-reference and serves effectively the same purpose.

If there is metadata that you would like stored across write/evict policies, the storage object will store it uniquely for the entity being operated on. A common example of needing a storage option is to compare previous and current field values.

Without a storage option, a write policy would only let you access the current properties of an entity, after the write. Now clients will be able to compare changes to fields which can be helpful in a number of scenarios:

```
CreateEmployeeResponse: {
  onWrite: {
    EmployeesResponse: (
      { readField },
      { ref, storage }
    ) => {
      const isActive = readField(
        'active',
        ref
      );

      const hasBecomeActive = isActive && !storage.isActive;
      if (hasBecomeActive) {
        doSomething();
      }

      storage.isActive = isActive;
    },
  },
};
```