### PR TITLE
Do not evaluate read policies for missing entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+1.0.0-beta7 (Dan Reynolds)
+
+- Fix issue where read policies were attempted to be evaluated for non-normalized entities not yet in the cache if they had a different store field name with the same name
+  already written in the cache.
+
 1.0.0-beta6 (Dan Reynolds)
 
 - Adds a `storage` dictionary by unique `storeFieldName` for queries or `ID` for normalized entities in the policy action object so that arbitrary meta information can be stored across multiple policy action invocations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta5",
+  "version": "1.0.0-beta6",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta6",
+  "version": "1.0.0-beta7",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/policies/InvalidationPolicyManager.ts
+++ b/src/policies/InvalidationPolicyManager.ts
@@ -185,7 +185,6 @@ export default class InvalidationPolicyManager {
 
       entityCacheTime = entityForStoreFieldName.cacheTime;
     } else {
-
       entityCacheTime = typeMapEntity.cacheTime;
     }
 


### PR DESCRIPTION
Resolves issue outlined in https://github.com/NerdWalletOSS/apollo-invalidation-policies/issues/2. Thanks to @maury91 and @hwhh for pointing out this issue. I first hadn't been able to repro but the point from @hwhh recently that it occurs for non-normalized entities with different store field names helped me repro it.

The issue was that if you have read eviction policies enabled using the `timeToLive` config and are fetching a field with particular variables that is not currently in the cache, but that same field is already in the cache with different variables, then it would error out because the cache will try and diff that entity as part of a `cache-and-network` style query to get the current value, triggering a read policy check for an entity that isn't yet present. Later when it comes back from the network it gets written into the cache and will have a time to live, but in the case where it first is diff'd and is not present we should just abort trying to run a read policy on an entity that isn't in the cache altogether.