### PR TITLE
fix write on write policy handling when mutation has args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.0-beta8 (Dan Reynolds)
+
+- Add test for Write-on-Write policies where the mutation has arguments and fix the Readme to illustrate how to correctly write the invalidation policy in that case
 
 1.0.0-beta7 (Dan Reynolds)
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ export default new ApolloClient({
               modify({
                 fields: {
                   [storeFieldName]: (employeesResponse) => {
-                    const createdEmployeeResponse = readField(parent.storeFieldName, parent.ref);
+                    const createdEmployeeResponse = readField({
+                      fieldName: parent.fieldName,
+                      args: parent.variables,
+                      ref: parent.ref,
+                    });
                     return {
                       ...employeesResponse,
                       data: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta7",
+  "version": "1.0.0-beta8",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -28,7 +28,7 @@ export enum ReadResultStatus {
  * Processes the result of a cache read/write to run invalidation policies on the deeply nested objects.
  */
 export class CacheResultProcessor {
-  constructor(private config: CacheResultProcessorConfig) {}
+  constructor(private config: CacheResultProcessorConfig) { }
 
   private getFieldsForQuery(
     options: Cache.ReadOptions<any> | Cache.WriteOptions<any, any>


### PR DESCRIPTION
There was no test for the scenario where the mutation that triggers a Write policy had arguments. An update to the Apollo 3 cache means that the old invocation:

```
readField(parent.storeFieldName, parent.ref);
```

no longer works if the parent had variables, as you can no longer read using the store field name. Instead we need to use:

```
readField({
  fieldName: parent.fieldName,
  args: parent.variables,
  ref: parent.ref
});
```
in the case where the parent could had variables. This was missed in the tests because there was no mutation with variables. A new test to catch this has been added and the README has been updated with the proper invocation.