### PR TITLE
add support for reporting on all expired entities without removing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ const cache = new InvalidationPolicyCache({
 | `modify`                      | `modify` API from Apollo cache     |
 | `readField`                   | `readField` API from Apollo cache  |
 
-| Extended cache API | Description                                                                                | Return Type                                           |
-| -------------------| -------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| `expire`           | Evicts all expired entities from the cache based on their type's or the global timeToLive. | String[] - List of entity IDs evicted from the cache. |
+| Extended cache API | Description                                                                                | Return Type                                                   |
+| -------------------| -------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `expire`           | Evicts all expired entities from the cache based on their type's or the global timeToLive. | String[] - List of expired entity IDs evicted from the cache. |
+| `expiredEntities`  | Returns all expired entities still present in the cache                                    | String[] - List of expired entities in the cache.             |
 
 | Policy Action Entity | Description                                             | Type               | Example                                                                                     |
 | ---------------------| --------------------------------------------------------|--------------------| ---------------------------------------------------------------------------------------------|

--- a/src/audit/InvalidationPolicyManagerAuditor.ts
+++ b/src/audit/InvalidationPolicyManagerAuditor.ts
@@ -24,12 +24,19 @@ export default class InvalidationPolicyManagerAuditor extends InvalidationPolicy
     this.auditLog = config.auditLog;
   }
 
-  runReadPolicy(
+  runReadPolicy({
+    typename,
+    dataId,
+    fieldName,
+    storeFieldName,
+    reportOnly = false,
+  }: {
     typename: string,
     dataId: string,
     fieldName?: string,
-    storeFieldName?: string
-  ) {
+    storeFieldName?: string,
+    reportOnly: boolean,
+  }) {
     this.auditLog.log(
       "Running read policy",
       AuditType.Read,
@@ -42,7 +49,13 @@ export default class InvalidationPolicyManagerAuditor extends InvalidationPolicy
       }
     );
 
-    return super.runReadPolicy(typename, dataId, fieldName, storeFieldName);
+    return super.runReadPolicy({
+      typename,
+      dataId,
+      fieldName,
+      storeFieldName,
+      reportOnly,
+    });
   }
 
   runWritePolicy(typeName: string, policyMeta: PolicyActionMeta) {

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -90,10 +90,10 @@ export class CacheResultProcessor {
           ) {
             entityTypeMap.renewEntity(id);
           }
-          const evicted = invalidationPolicyManager.runReadPolicy(
-            __typename,
-            id
-          );
+          const evicted = invalidationPolicyManager.runReadPolicy({
+            typename: __typename,
+            dataId: id
+          });
 
           if (evicted) {
             if (_.isPlainObject(parentResult) && fieldNameOrIndex) {
@@ -173,12 +173,12 @@ export class CacheResultProcessor {
             ) {
               entityTypeMap.renewEntity(dataId, storeFieldName);
             }
-            const evicted = invalidationPolicyManager.runReadPolicy(
+            const evicted = invalidationPolicyManager.runReadPolicy({
               typename,
               dataId,
               fieldName,
               storeFieldName
-            );
+            });
 
             if (evicted) {
               delete (result as Record<string, any>)[fieldName];

--- a/tests/InvalidationPolicyManager.test.ts
+++ b/tests/InvalidationPolicyManager.test.ts
@@ -249,12 +249,20 @@ describe("InvalidationPolicyManager", () => {
   describe('#runReadPolicy', () => {
     test('should not evaluate a read policy for normalized entities that are not in the cache', () => {
       const employee = Employee();
-      expect(invalidationPolicyManager.runReadPolicy(employee.__typename, employee.id)).toEqual(true);
+      expect(invalidationPolicyManager.runReadPolicy({
+        typename: employee.__typename,
+        dataId: employee.id
+      })).toEqual(false);
     });
 
     test('should not evaluate a read policy for non-normalized entities that are not in the cache', () => {
       entityTypeMap.write('EmployeesResponse', 'ROOT_QUERY', 'employees({"name":"Tester1"})');
-      expect(invalidationPolicyManager.runReadPolicy('EmployeesResponse', 'ROOT_QUERY', 'employees', 'employees({"name":"Tester2"})')).toEqual(true);
+      expect(invalidationPolicyManager.runReadPolicy({
+        typename: 'EmployeesResponse',
+        dataId: 'ROOT_QUERY',
+        fieldName: 'employees',
+        storeFieldName: 'employees({"name":"Tester2"})',
+      })).toEqual(false);
     });
   })
 });


### PR DESCRIPTION
Adds an `expiredEntities` function that returns the expired entities without removing them as per the desired behavior in #6 . While the `expire` API will evict expired entities eagerly, the `expiredEntities` API returns all expired entities that still reside in the cache. 

You can see an example usage response in the test case: https://github.com/NerdWalletOSS/apollo-invalidation-policies/pull/14/files#diff-4f07926aa6eb7cbfd9be045135454fa78a60d7e326e1aa9556c8f1586c728809R2734