### PR TITLE
add support for default policy actions on any type write/evict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.0-beta10 (Dan Reynolds)
+
+- Add support for a default policy action to perform side effects whenever a specific type is written/evicted from the cache
+
 1.0.0-beta9 (Dan Reynolds)
 
 - Add `expiredEntities` API for accessing the expired entities in the cache without evicting them

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ const cache = new InvalidationPolicyCache({
         renewalPolicy: RenewalPolicy,
         PolicyEvent: {
           Typename: (PolicyActionCacheOperation, PolicyActionEntity) => {}
+          __default: (PolicyActionCacheOperation, DefaultPolicyActionEntity) => {}
         },
       }
     }
@@ -71,6 +72,11 @@ const cache = new InvalidationPolicyCache({
 | `storage`            | An object for storing unique entity metadata across policy action invocations | Object            | `{}`                                                                        |
 | `parent`             | The parent entity that triggered the PolicyEvent        | PolicyActionEntity  | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
 
+| Default Policy Action Entity | Description                                                                   | Type               | Example                                                                                     |
+| -----------------------------| ------------------------------------------------------------------------------|---------------------| ---------------------------------------------------------------------------------------------|
+| `storage`                    | An object for storing unique entity metadata across policy action invocations | Object              | `{}`                                                                        |
+| `parent`                     | The parent entity that triggered the PolicyEvent                              | PolicyActionEntity  | `{ id: 'ROOT_QUERY', fieldName: 'deleteEmployees', storeFieldName: 'deleteEmployees({}), ref: { __ref: 'ROOT_QUERY' }, variables: {} }'` |
+
 ```javascript
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 import { InvalidationPolicyCache } from "apollo-invalidation-policies";
@@ -101,6 +107,14 @@ export default new ApolloClient({
             },
           }
         },
+        EmployeeMessage: {
+          // Perform a side-effect whenever an employee message is evicted
+          onEvict: {
+            __default: (_cacheOperations, { parent: { id } }) => {
+              console.log(`Employee message ${id} was evicted`);
+            },
+          },
+        },
         CreateEmployeeResponse: {
           // Add an entity to a cached query when the parent type is written
           onWrite: {
@@ -124,7 +138,7 @@ export default new ApolloClient({
                 }
               });
             },
-          }
+          },
           EmployeesResponse: {
             // Assign a time-to-live for types in the store. If accessed beyond their TTL,
             // they are evicted and no data is returned.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta9",
+  "version": "1.0.0-beta10",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/policies/InvalidationPolicyManager.ts
+++ b/src/policies/InvalidationPolicyManager.ts
@@ -101,9 +101,19 @@ export default class InvalidationPolicyManager {
     if (!typePolicyForEvent) {
       return;
     }
-    Object.keys(typePolicyForEvent).forEach((typeName: string) => {
-      const typeMapEntities = entityTypeMap.readEntitiesByType(typeName) ?? {};
-      const policyAction = typePolicyForEvent[typeName];
+
+    const { __default: defaultPolicyAction, ...restTypes } = typePolicyForEvent;
+
+    if (defaultPolicyAction) {
+      defaultPolicyAction(mutedCacheOperations, {
+        storage: this.getPolicyActionStorage(`${typeName}__default`),
+        ...policyMeta,
+      });
+    }
+
+    Object.keys(restTypes).forEach((typePolicyTypeName: string) => {
+      const typeMapEntities = entityTypeMap.readEntitiesByType(typePolicyTypeName) ?? {};
+      const policyAction = typePolicyForEvent[typePolicyTypeName];
 
       Object.values(typeMapEntities).forEach((typeMapEntity) => {
         const { dataId, fieldName, storeFieldNames } = typeMapEntity;

--- a/src/policies/InvalidationPolicyManager.ts
+++ b/src/policies/InvalidationPolicyManager.ts
@@ -102,7 +102,7 @@ export default class InvalidationPolicyManager {
       return;
     }
 
-    const { __default: defaultPolicyAction, ...restTypes } = typePolicyForEvent;
+    const { __default: defaultPolicyAction, ...restTypePolicyTypeNames } = typePolicyForEvent;
 
     if (defaultPolicyAction) {
       defaultPolicyAction(mutedCacheOperations, {
@@ -111,7 +111,7 @@ export default class InvalidationPolicyManager {
       });
     }
 
-    Object.keys(restTypes).forEach((typePolicyTypeName: string) => {
+    Object.keys(restTypePolicyTypeNames).forEach((typePolicyTypeName: string) => {
       const typeMapEntities = entityTypeMap.readEntitiesByType(typePolicyTypeName) ?? {};
       const policyAction = typePolicyForEvent[typePolicyTypeName];
 

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -50,9 +50,16 @@ export type PolicyAction = (
   entity: PolicyActionEntity
 ) => void;
 
+export type DefaultPolicyAction = (
+  cacheOperations: PolicyActionCacheOperations,
+  entity: Pick<PolicyActionEntity, 'storage' | 'parent'>
+) => void;
+
 export type InvalidationPolicy = {
   [lifecycleEvent in InvalidationPolicyLifecycleEvent]?: {
     [typeName: string]: PolicyAction;
+  } & {
+    __default?: DefaultPolicyAction;
   };
 } & {
   timeToLive?: number;

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -2580,6 +2580,38 @@ describe("Cache", () => {
     });
   });
 
+  describe('with a default cache policy', () => {
+    let sideEffect: string;
+
+    beforeEach(() => {
+      cache = new InvalidationPolicyCache({
+        invalidationPolicies: {
+          types: {
+            EmployeesResponse: {
+              onWrite: {
+                __default: (_cacheOperations, { parent: { storeFieldName } }) => {
+                  sideEffect = `${storeFieldName} field written to the cache`;
+                }
+              },
+            },
+          },
+        },
+      });
+      cache.writeQuery({
+        query: employeesQuery,
+        data: employeesResponse,
+      });
+    });
+
+    test("should run the default policy action on parent write", () => {
+      cache.writeQuery({
+        query: employeesQuery,
+        data: employeesResponse,
+      });
+      expect(sideEffect).toEqual('employees field written to the cache');
+    });
+  })
+
   describe("#expire", () => {
     let dateNowSpy: any;
 


### PR DESCRIPTION
It can be the case that a user might need to specify a policy action for when a particular type is written/evicted in order to perform a side-effect, but that side-effect is not tied to any particular type. For example, a user might want to log out any time a particular entity is changed and not care about binding the parent event to any particular child event.

This feature adds support for a `__default` type event that can be used to perform arbitrary side effects.