### PR TITLE
update readField to default to use the ROOT_QUERY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.0-beta11 (Dan Reynolds)
+
+- Default the `readPolicy` function in the policy action to use the ROOT_QUERY similarly to how the policies module does in apollo/client
+
 1.0.0-beta10 (Dan Reynolds)
 
 - Add support for a default policy action to perform side effects whenever a specific type is written/evicted from the cache

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta10",
+  "version": "1.0.0-beta11",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -64,13 +64,19 @@ export default class InvalidationPolicyCache extends InMemoryCache {
       return;
     }
 
+    const options = typeof fieldNameOrOptions === "string"
+      ? {
+        fieldName: fieldNameOrOptions,
+        from,
+      }
+      : fieldNameOrOptions;
+
+    if (void 0 === options.from) {
+      options.from = { __ref: 'ROOT_QUERY' };
+    }
+
     return this.policies.readField<T>(
-      typeof fieldNameOrOptions === "string"
-        ? {
-          fieldName: fieldNameOrOptions,
-          from,
-        }
-        : fieldNameOrOptions,
+      options,
       {
         store: this.entityStoreRoot,
       }


### PR DESCRIPTION
The Apollo readField API wrapper in the policies module https://github.com/apollographql/apollo-client/blob/master/src/cache/inmemory/policies.ts#L723:L723 defaults to using the the ROOT_QUERY as the reference object if none is provided. This convenience is a welcome change to this lib as well.