### PR TITLE
add support for activating/deactivating policy events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+1.0.0-beta12 (Dan Reynolds)
+
+- Add support for dynamically activating/deactivating policy events
+
 1.0.0-beta11 (Dan Reynolds)
 
 - Default the `readPolicy` function in the policy action to use the ROOT_QUERY similarly to how the policies module does in apollo/client

--- a/README.md
+++ b/README.md
@@ -57,10 +57,13 @@ const cache = new InvalidationPolicyCache({
 | `modify`                      | `modify` API from Apollo cache     |
 | `readField`                   | `readField` API from Apollo cache  |
 
-| Extended cache API | Description                                                                                | Return Type                                                   |
-| -------------------| -------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| `expire`           | Evicts all expired entities from the cache based on their type's or the global timeToLive. | String[] - List of expired entity IDs evicted from the cache. |
-| `expiredEntities`  | Returns all expired entities still present in the cache                                    | String[] - List of expired entities in the cache.             |
+| Extended cache API       | Description                                                                               | Return Type                                                  | Arguments                 |
+| -------------------------| ------------------------------------------------------------------------------------------|--------------------------------------------------------------|---------------------------|
+| `expire`                 | Evicts all expired entities from the cache based on their type's or the global timeToLive | String[] - List of expired entity IDs evicted from the cache | N/A                       |
+| `expiredEntities`        | Returns all expired entities still present in the cache                                   | String[] - List of expired entities in the cache             | N/A                       |
+| `activePolicyEvents`     | Returns all active policy events (Read, Write, Evict)                                     | InvalidationPolicyEvent[] - List of active policy events     | N/A                       |
+| `activatePolicyEvents`   | Activates the provided policy events, defaults to all                                     | void                                                         | InvalidationPolicyEvent[] |
+| `deactivatePolicyEvents` | Dectivates the provided policy events, defaults to all                                    | void                                                         | InvalidationPolicyEvent[] |
 
 | Policy Action Entity | Description                                             | Type               | Example                                                                                     |
 | ---------------------| --------------------------------------------------------|--------------------| ---------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ const cache = new InvalidationPolicyCache({
 | `modify`                      | `modify` API from Apollo cache     |
 | `readField`                   | `readField` API from Apollo cache  |
 
-| Extended cache API       | Description                                                                               | Return Type                                                  | Arguments                 |
-| -------------------------| ------------------------------------------------------------------------------------------|--------------------------------------------------------------|---------------------------|
-| `expire`                 | Evicts all expired entities from the cache based on their type's or the global timeToLive | String[] - List of expired entity IDs evicted from the cache | N/A                       |
-| `expiredEntities`        | Returns all expired entities still present in the cache                                   | String[] - List of expired entities in the cache             | N/A                       |
-| `activePolicyEvents`     | Returns all active policy events (Read, Write, Evict)                                     | InvalidationPolicyEvent[] - List of active policy events     | N/A                       |
-| `activatePolicyEvents`   | Activates the provided policy events, defaults to all                                     | void                                                         | InvalidationPolicyEvent[] |
-| `deactivatePolicyEvents` | Dectivates the provided policy events, defaults to all                                    | void                                                         | InvalidationPolicyEvent[] |
+| Extended cache API       | Description                                                                               | Return Type                                                  | Arguments                    |
+| -------------------------| ------------------------------------------------------------------------------------------|--------------------------------------------------------------|------------------------------|
+| `expire`                 | Evicts all expired entities from the cache based on their type's or the global timeToLive | String[] - List of expired entity IDs evicted from the cache | N/A                          |
+| `expiredEntities`        | Returns all expired entities still present in the cache                                   | String[] - List of expired entities in the cache             | N/A                          |
+| `activePolicyEvents`     | Returns all active policy events (Read, Write, Evict)                                     | InvalidationPolicyEvent[] - List of active policy events     | N/A                          |
+| `activatePolicyEvents`   | Activates the provided policy events, defaults to all                                     | void                                                         | ...InvalidationPolicyEvent[] |
+| `deactivatePolicyEvents` | Dectivates the provided policy events, defaults to all                                    | void                                                         | ...InvalidationPolicyEvent[] |
 
 | Policy Action Entity | Description                                             | Type               | Example                                                                                     |
 | ---------------------| --------------------------------------------------------|--------------------| ---------------------------------------------------------------------------------------------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta11",
+  "version": "1.0.0-beta12",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -98,6 +98,6 @@ export interface InvalidationPolicyManagerConfig {
   entityTypeMap: EntityTypeMap;
 }
 
-export type InvalidationPolicyActivation = {
+export type InvalidationPolicyEventActivation = {
   [key in InvalidationPolicyEvent]: boolean;
 };

--- a/tests/InvalidationPolicyCache.test.ts
+++ b/tests/InvalidationPolicyCache.test.ts
@@ -3,7 +3,7 @@ import { gql } from "@apollo/client";
 import { InvalidationPolicyCache } from "../src";
 import Employee from "./fixtures/employee";
 import EmployeeMessage from "./fixtures/employeeMessage";
-import { RenewalPolicy } from "../src/policies/types";
+import { InvalidationPolicyEvent, RenewalPolicy } from "../src/policies/types";
 
 describe("Cache", () => {
   let cache: InvalidationPolicyCache;
@@ -2792,7 +2792,70 @@ describe("Cache", () => {
         },
       });
     });
-  })
+  });
+
+  describe('#activatePolicies', () => {
+    beforeEach(() => {
+      cache = new InvalidationPolicyCache();
+    });
+
+    describe('with no policies passed', () => {
+      test('should activate all policies', () => {
+        expect(cache.activePolicyEvents()).toEqual([]);
+        cache.activatePolicyEvents();
+        expect(cache.activePolicyEvents()).toEqual(expect.arrayContaining([
+          InvalidationPolicyEvent.Read,
+          InvalidationPolicyEvent.Write,
+          InvalidationPolicyEvent.Evict,
+        ]));
+      })
+    });
+
+    describe('with policies passed', () => {
+      test('should activate the provided policies', () => {
+        expect(cache.activePolicyEvents()).toEqual([]);
+        cache.activatePolicyEvents(InvalidationPolicyEvent.Read);
+        expect(cache.activePolicyEvents()).toEqual(expect.arrayContaining([
+          InvalidationPolicyEvent.Read,
+        ]));
+      })
+    });
+  });
+
+  describe('#deactivatePolicies', () => {
+    beforeEach(() => {
+      cache = new InvalidationPolicyCache();
+    });
+
+    describe('with no policies passed', () => {
+      test('should deactivate all policies', () => {
+        cache.activatePolicyEvents();
+        expect(cache.activePolicyEvents()).toEqual(expect.arrayContaining([
+          InvalidationPolicyEvent.Read,
+          InvalidationPolicyEvent.Write,
+          InvalidationPolicyEvent.Evict,
+        ]));
+        cache.deactivatePolicyEvents();
+        expect(cache.activePolicyEvents()).toEqual(expect.arrayContaining([]));
+      })
+    });
+
+    describe('with policies passed', () => {
+      test('should deactivate the provided policies', () => {
+        cache.activatePolicyEvents();
+        expect(cache.activePolicyEvents()).toEqual(expect.arrayContaining([
+          InvalidationPolicyEvent.Read,
+          InvalidationPolicyEvent.Write,
+          InvalidationPolicyEvent.Evict,
+        ]));
+        cache.deactivatePolicyEvents(InvalidationPolicyEvent.Read);
+        expect(cache.activePolicyEvents()).toEqual(expect.arrayContaining([
+          InvalidationPolicyEvent.Write,
+          InvalidationPolicyEvent.Evict,
+        ]));
+      })
+    });
+  });
 
   describe("#extract", () => {
     describe("without invalidation extracted", () => {

--- a/tests/InvalidationPolicyManager.test.ts
+++ b/tests/InvalidationPolicyManager.test.ts
@@ -211,13 +211,13 @@ describe("InvalidationPolicyManager", () => {
       });
 
       expect(
-        invalidationPolicyManager.isPolicyActive(InvalidationPolicyEvent.Read)
+        invalidationPolicyManager.isPolicyEventActive(InvalidationPolicyEvent.Read)
       ).toEqual(true);
       expect(
-        invalidationPolicyManager.isPolicyActive(InvalidationPolicyEvent.Write)
+        invalidationPolicyManager.isPolicyEventActive(InvalidationPolicyEvent.Write)
       ).toEqual(true);
       expect(
-        invalidationPolicyManager.isPolicyActive(InvalidationPolicyEvent.Evict)
+        invalidationPolicyManager.isPolicyEventActive(InvalidationPolicyEvent.Evict)
       ).toEqual(true);
     });
 
@@ -235,13 +235,13 @@ describe("InvalidationPolicyManager", () => {
       });
 
       expect(
-        invalidationPolicyManager.isPolicyActive(InvalidationPolicyEvent.Read)
+        invalidationPolicyManager.isPolicyEventActive(InvalidationPolicyEvent.Read)
       ).toEqual(false);
       expect(
-        invalidationPolicyManager.isPolicyActive(InvalidationPolicyEvent.Write)
+        invalidationPolicyManager.isPolicyEventActive(InvalidationPolicyEvent.Write)
       ).toEqual(false);
       expect(
-        invalidationPolicyManager.isPolicyActive(InvalidationPolicyEvent.Evict)
+        invalidationPolicyManager.isPolicyEventActive(InvalidationPolicyEvent.Evict)
       ).toEqual(false);
     });
   });


### PR DESCRIPTION
There was a feature request for being able to turn off policy events dynamically. One use case is if a cache has enabled TTLs, but their device goes offline and they'd rather not evict expired entities until they are online again. The `activatePolicies` and `deactivatePolicies` API will allow them to turn on/off the Read, Write, Evict events as needed. In that case, they would turn off the `Read` event which is applied whenever an entity is read and evicts it if it has exceeded its TTL.