### PR TITLE
expose a few more types that clients might want to use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 export { InvalidationPolicyCache } from "./cache";
 export { InvalidationPolicyCacheAuditor } from "./audit";
 export {
+  DefaultPolicyAction,
   InvalidationPolicies,
+  InvalidationPolicy,
+  InvalidationPolicyEvent,
+  PolicyAction,
   PolicyActionEntity,
   PolicyActionFields,
   RenewalPolicy,


### PR DESCRIPTION
There are a could more potentially useful public types that weren't being export from the index.