### PR TITLE
fix: make imports work in node environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.0-beta13 (Dan Reynolds)
+
+- Short-term fix that adds support for running the lib in environments that cannot handle import statements by removing imports from non-public Apollo APIs.
+The required imports will be made available in an upcoming version of Apollo Client and we'll switch to that better fix at that time.
 
 1.0.0-beta12 (Dan Reynolds)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta12",
+  "version": "1.0.0-beta13",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache/CacheResultProcessor.ts
+++ b/src/cache/CacheResultProcessor.ts
@@ -1,21 +1,17 @@
 import _ from "lodash";
 import { FieldNode, SelectionNode } from "graphql";
 import { Cache, makeReference } from "@apollo/client";
-import { maybeDeepFreeze } from "@apollo/client/utilities/common/maybeDeepFreeze";
-import {
-  getFragmentDefinitions,
-  getOperationDefinition,
-} from "@apollo/client/utilities/graphql/getFromAST";
-import { CacheResultProcessorConfig } from "./types";
-import { makeEntityId, isQuery } from "../helpers";
-import {
-  resultKeyNameFromField,
-  isField,
-} from "@apollo/client/utilities/graphql/storeUtils";
 import {
   createFragmentMap,
+  getFragmentDefinitions,
   getFragmentFromSelection,
-} from "@apollo/client/utilities/graphql/fragments";
+  getOperationDefinition,
+  isField,
+  maybeDeepFreeze,
+  resultKeyNameFromField,
+} from "@apollo/client/utilities";
+import { CacheResultProcessorConfig } from "./types";
+import { makeEntityId, isQuery } from "../helpers";
 import { RenewalPolicy } from "../policies/types";
 
 export enum ReadResultStatus {

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -7,15 +7,12 @@ import {
   StoreObject,
   makeReference,
 } from "@apollo/client";
-import { ReadFieldOptions } from "@apollo/client/cache/core/types/common";
-import { EntityStore } from "@apollo/client/cache/inmemory/entityStore";
-import { fieldNameFromStoreName } from "@apollo/client/cache/inmemory/helpers";
 import InvalidationPolicyManager from "../policies/InvalidationPolicyManager";
 import { EntityStoreWatcher, EntityTypeMap } from "../entity-store";
-import { makeEntityId, isQuery, maybeDeepClone } from "../helpers";
+import { makeEntityId, isQuery, maybeDeepClone, fieldNameFromStoreName } from "../helpers";
 import { InvalidationPolicyCacheConfig } from "./types";
 import { CacheResultProcessor, ReadResultStatus } from "./CacheResultProcessor";
-import { InvalidationPolicyEvent } from "../policies/types";
+import { InvalidationPolicyEvent, ReadFieldOptions } from "../policies/types";
 
 /**
  * Extension of Apollo in-memory cache which adds support for invalidation policies.
@@ -24,7 +21,7 @@ export default class InvalidationPolicyCache extends InMemoryCache {
   protected entityTypeMap: EntityTypeMap;
   protected invalidationPolicyManager: InvalidationPolicyManager;
   protected cacheResultProcessor: CacheResultProcessor;
-  protected entityStoreRoot: EntityStore.Root;
+  protected entityStoreRoot: any;
   protected isBroadcasting: boolean;
 
   constructor(config: InvalidationPolicyCacheConfig = {}) {

--- a/src/entity-store/EntityStoreWatcher.ts
+++ b/src/entity-store/EntityStoreWatcher.ts
@@ -1,22 +1,20 @@
 import _ from "lodash";
 import { StoreObject } from "@apollo/client";
 import EntityTypeMap from "./EntityTypeMap";
-import { EntityStore } from "@apollo/client/cache/inmemory/entityStore";
 import { NormalizedCacheObjectWithInvalidation } from "./types";
-import { Policies } from "@apollo/client/cache/inmemory/policies";
 import { makeEntityId, isQuery } from "../helpers";
 
 interface EntityStoreWatcherConfig {
-  entityStore: EntityStore;
+  entityStore: any;
   entityTypeMap: EntityTypeMap;
-  policies: Policies;
+  policies: any;
 }
 
 type EntityStoreWatcherStoreFunctions = {
-  clear: EntityStore["clear"];
-  delete: EntityStore["delete"];
-  merge: EntityStore["merge"];
-  replace: EntityStore["replace"];
+  clear: any;
+  delete: any;
+  merge: any;
+  replace: any;
 };
 
 /**
@@ -58,10 +56,10 @@ export default class EntityStoreWatcher {
     const storeFieldName =
       fieldName && args
         ? policies.getStoreFieldName({
-            typename: entity ? entity.typename : undefined,
-            fieldName,
-            args,
-          })
+          typename: entity ? entity.typename : undefined,
+          fieldName,
+          args,
+        })
         : undefined;
     entityTypeMap.evict(dataId, storeFieldName || fieldName);
 

--- a/src/entity-store/EntityTypeMap.ts
+++ b/src/entity-store/EntityTypeMap.ts
@@ -1,6 +1,5 @@
 import _ from "lodash";
-import { fieldNameFromStoreName } from "@apollo/client/cache/inmemory/helpers";
-import { makeEntityId, isQuery } from "../helpers";
+import { makeEntityId, isQuery, fieldNameFromStoreName } from "../helpers";
 import {
   EntitiesByType,
   EntitiesById,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -26,3 +26,9 @@ export function makeEntityId(
 // https://github.com/apollographql/apollo-client/blob/master/src/utilities/common/maybeDeepFreeze.ts#L20:L20
 export const maybeDeepClone = (obj: any) =>
   _.isPlainObject(obj) && Object.isFrozen(obj) ? _.cloneDeep(obj) : obj;
+
+export var TypeOrFieldNameRegExp = /^[_a-z][_0-9a-z]*/i;
+export function fieldNameFromStoreName(storeFieldName: string) {
+  var match = storeFieldName.match(TypeOrFieldNameRegExp);
+  return match ? match[0] : storeFieldName;
+}

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -1,6 +1,17 @@
+import { FieldNode } from 'graphql';
 import { Cache, Reference, StoreObject, StoreValue } from "@apollo/client";
-import { ReadFieldOptions } from "@apollo/client/cache/core/types/common";
 import EntityTypeMap from "../entity-store/EntityTypeMap";
+export interface FieldSpecifier {
+  typename?: string;
+  fieldName: string;
+  field?: FieldNode;
+  args?: Record<string, any>;
+  variables?: Record<string, any>;
+}
+
+export interface ReadFieldOptions extends FieldSpecifier {
+  from?: StoreObject | Reference;
+}
 
 export enum InvalidationPolicyEvent {
   Write = "Write",


### PR DESCRIPTION
Thanks to @foodproduct we can expect all the types we need exposed in Apollo Client 3.4 👏 until that is released and hardened, in the near term we'll reduce the type safety and DRYness of the code somewhat by replacing some of the imports/utilities with `any` types and inlined functions so that we can unblock getting the lib working in environments that cannot handle `import` statements.

Permanent fix PR detailed here:
https://github.com/NerdWalletOSS/apollo-invalidation-policies/pull/18

