### PR TITLE
Compatibility with Apollo's `wrapDestructiveCacheMethod()`

### DIFF
--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -41,9 +41,9 @@ export default class InvalidationPolicyCache extends InMemoryCache {
       policies: invalidationPolicies,
       entityTypeMap: this.entityTypeMap,
       cacheOperations: {
-        evict: this.evict.bind(this),
-        modify: this.modify.bind(this),
-        readField: this.readField.bind(this),
+        evict: (options) => this.evict(options),
+        modify: (...args) => this.modify(...args),
+        readField: (...args) => this.readField(...args),
       },
     });
     this.cacheResultProcessor = new CacheResultProcessor({

--- a/src/cache/InvalidationPolicyCache.ts
+++ b/src/cache/InvalidationPolicyCache.ts
@@ -41,7 +41,7 @@ export default class InvalidationPolicyCache extends InMemoryCache {
       policies: invalidationPolicies,
       entityTypeMap: this.entityTypeMap,
       cacheOperations: {
-        evict: (options) => this.evict(options),
+        evict: (...args) => this.evict(...args),
         modify: (...args) => this.modify(...args),
         readField: (...args) => this.readField(...args),
       },

--- a/src/policies/types.ts
+++ b/src/policies/types.ts
@@ -78,11 +78,7 @@ export type InvalidationPolicy = {
 };
 
 export type CacheOperations = {
-  evict: (
-    options: Cache.EvictOptions,
-    fieldName?: string,
-    args?: Record<string, any>
-  ) => boolean;
+  evict: (options: Cache.EvictOptions) => boolean;
   modify: (options: Cache.ModifyOptions) => boolean;
   readField: (
     fieldNameOrOptions?: string | ReadFieldOptions | undefined,
@@ -91,11 +87,7 @@ export type CacheOperations = {
 };
 
 export type PolicyActionCacheOperations = {
-  evict: (
-    options: Omit<Cache.EvictOptions, "broadcast">,
-    fieldName?: string,
-    args?: Record<string, any>
-  ) => boolean;
+  evict: (options: Omit<Cache.EvictOptions, "broadcast">) => boolean;
   modify: (options: Omit<Cache.ModifyOptions, "broadcast">) => boolean;
   readField: (
     fieldNameOrOptions?: string | ReadFieldOptions | undefined,


### PR DESCRIPTION
[Apollo's `QueryInfo` monkey-patches a few methods on the cache](https://github.com/apollographql/apollo-client/blob/main/src/core/QueryInfo.ts#L90). We need to make sure that we internally call Apollo's monkey-methods. 🐒 

The issue happens when one query updates and causes an update to another query. If the data from the server is the same for that second update it'll prevent the cache write, unless Apollo has noticed a "destructive method call", like `evict()`.

Error reproduced here: https://codesandbox.io/s/apollo-ttl-caching-ecqx8?file=/src/App.tsx