### PR TITLE
fix bug where read renewal policy would try to renew non existent entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.0-beta15 (Dan Reynolds)
+
+- Fix bug where a renew-on-read policy would try to update the cache time for entities not present in the cache
+
 1.0.0-beta14 (Dan Reynolds)
 
 - Bugfix for fixing eviction/mutation changes to the cache via the wrapper `wrapDestructiveCacheMethod` function. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-invalidation-policies",
-  "version": "1.0.0-beta14",
+  "version": "1.0.0-beta15",
   "description": "An extension to the InMemoryCache from Apollo for type-based invalidation policies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/entity-store/EntityTypeMap.ts
+++ b/src/entity-store/EntityTypeMap.ts
@@ -204,7 +204,10 @@ export default class EntityTypeMap {
     if (entity) {
       const cacheTime = Date.now();
       if (isQuery(dataId) && storeFieldName) {
-        entity.storeFieldNames!.entries[storeFieldName]!.cacheTime = cacheTime;
+        const storeFieldNameEntry = entity.storeFieldNames!.entries[storeFieldName];
+        if (storeFieldNameEntry) {
+          storeFieldNameEntry.cacheTime = cacheTime;
+        }
       } else {
         entity.cacheTime = cacheTime;
       }

--- a/tests/EntityTypeMap.test.ts
+++ b/tests/EntityTypeMap.test.ts
@@ -302,4 +302,51 @@ describe("EntityTypeMap", () => {
       });
     });
   });
+
+  describe('#renewEntity', () => {
+    describe('when renewing a normalized entity', () => {
+      describe('that is present in the type map', () => {
+        test('should renew the entity', () => {
+          dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(0);
+          entityTypeMap = new EntityTypeMap();
+          dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(0);
+          entityTypeMap.write("Employee", "Employee:1");
+          dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(50);
+          entityTypeMap.renewEntity("Employee:1");
+          expect(entityTypeMap.readEntityById("Employee:1")?.cacheTime).toEqual(50);
+        });
+      });
+
+      describe('that is not present in the type map', () => {
+        test('should not renew the entity', () => {
+          entityTypeMap = new EntityTypeMap();
+          dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(0);
+          expect(() => entityTypeMap.renewEntity("Employee:1")).not.toThrow();
+        });
+      });
+    });
+
+    describe('when renewing a query entity', () => {
+      describe('that is present in the type map', () => {
+        test('should renew the entity', () => {
+          dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(0);
+          entityTypeMap = new EntityTypeMap();
+          dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(0);
+          entityTypeMap.write("EmployeesResponse", "ROOT_QUERY", "employees({id:1})");
+          dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(50);
+          entityTypeMap.renewEntity("ROOT_QUERY", "employees({id:1})");
+          expect(entityTypeMap.readEntityById("ROOT_QUERY.employees")!.storeFieldNames!.entries['employees({id:1})'].cacheTime).toEqual(50);
+        });
+      });
+
+      describe('that is not present in the type map', () => {
+        test('should not renew the entity', () => {
+          entityTypeMap = new EntityTypeMap();
+          dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(0);
+          entityTypeMap.write("EmployeesResponse", "ROOT_QUERY", "employees");
+          expect(() => entityTypeMap.renewEntity("ROOT_QUERY", "employees({id:1})")).not.toThrow();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Similarly to https://github.com/NerdWalletOSS/apollo-invalidation-policies/pull/11, we do not want to attempt to renew entities that are not existent in the cache and will be returned as missing from the cache.